### PR TITLE
Implement Document Read Write using Local Firebase SDK with Offscreen Google Auth login

### DIFF
--- a/README.md
+++ b/README.md
@@ -420,17 +420,22 @@ Remember to replace placeholder values (like YOUR_EXTENSION_ID, YOUR-CLIENT-ID, 
 If you found this guide helpful please give us a star and follow us on Dev.to for more guides
 [Dev.to](https://dev.to/lvn1)
 
-Additonal details:
+### Additonal details:
 
-in manifest.json
+**1** manifest.json
    content_security_policy must also have "app hosting url" for connect-src and frame-src both
    host permissions also need app hosting url
 
-in background.js
+**2** background.js
    following is added to chrome.runtime.onMessage.addListener method
        if (message.target === 'offscreen') return false;
 
-in signInWithPopup.js
+**3** signInWithPopup.js
    complete urls are needed 
    import { initializeApp } from 'https://www.gstatic.com/firebasejs/12.10.0/firebase-app.js';
     import { getAuth, signInWithPopup, GoogleAuthProvider } from 'https://www.gstatic.com/firebasejs/12.10.0/firebase-auth.js';
+
+**4** Security BrowserKey should have following to ensure maximum security without blocking app usage
+   1) chrome-extension://YOUR-EXTENSION-ID/*
+   2) https://your-project-id.web.app
+   3) https://your-project-id.firebaseapp.com

--- a/README.md
+++ b/README.md
@@ -420,3 +420,12 @@ Remember to replace placeholder values (like YOUR_EXTENSION_ID, YOUR-CLIENT-ID, 
 If you found this guide helpful please give us a star and follow us on Dev.to for more guides
 [Dev.to](https://dev.to/lvn1)
 
+Additonal details:
+
+in manifest.json
+   content_security_policy must also have "app hosting url" for connect-src and frame-src both
+   host permissions also need app hosting url
+
+in background.js
+   following is added to chrome.runtime.onMessage.addListener method
+       if (message.target === 'offscreen') return false;

--- a/README.md
+++ b/README.md
@@ -429,3 +429,8 @@ in manifest.json
 in background.js
    following is added to chrome.runtime.onMessage.addListener method
        if (message.target === 'offscreen') return false;
+
+in signInWithPopup.js
+   complete urls are needed 
+   import { initializeApp } from 'https://www.gstatic.com/firebasejs/12.10.0/firebase-app.js';
+    import { getAuth, signInWithPopup, GoogleAuthProvider } from 'https://www.gstatic.com/firebasejs/12.10.0/firebase-auth.js';

--- a/chrome-extension/package.json
+++ b/chrome-extension/package.json
@@ -11,11 +11,9 @@
   "license": "ISC",
   "devDependencies": {
     "copy-webpack-plugin": "^12.0.2",
-    "html-webpack-plugin": "^5.6.0",
-    "webpack": "^5.94.0",
+    "firebase": "^12.10.0",
+    "html-webpack-plugin": "^5.6.6",
+    "webpack": "^5.105.4",
     "webpack-cli": "^5.1.4"
-  },
-  "dependencies": {
-    "firebase": "^10.13.1"
   }
 }

--- a/chrome-extension/public/manifest.json
+++ b/chrome-extension/public/manifest.json
@@ -9,7 +9,12 @@
     "offscreen"
   ],
   "host_permissions": [
-    "https://*.firebaseapp.com/*"
+    "https://your-project-id.web.app/*",
+    "https://*.firebaseapp.com/*",
+    "https://accounts.google.com/*",
+    "https://securetoken.googleapis.com/*",
+    "https://www.googleapis.com/*",
+    "https://www.gstatic.com/*"
   ],
   "background": {
     "service_worker": "background.js",
@@ -24,6 +29,9 @@
       "matches": ["<all_urls>"]
     }
   ],
+  "content_security_policy": {
+    "extension_pages": "script-src 'self'; object-src 'self'; connect-src 'self' https://firestore.googleapis.com https://your-project-id.web.app/* https://securetoken.googleapis.com https://www.googleapis.com https://identitytoolkit.googleapis.com; frame-src 'self' https://accounts.google.com https://your-project-id.web.app;"
+  },
   "oauth2": {
     "client_id": "YOUR-GOOGLE-OAUTH-CLIENT-ID.apps.googleusercontent.com",
     "scopes": [

--- a/chrome-extension/public/offscreen.js
+++ b/chrome-extension/public/offscreen.js
@@ -3,14 +3,16 @@ const FIREBASE_HOSTING_URL = 'https://your-project-id.web.app'; // Replace with 
 const iframe = document.createElement('iframe');
 iframe.src = FIREBASE_HOSTING_URL;
 document.body.appendChild(iframe);
+console.log("OFFSCREEN BOOTSTRAP: Script is running!");
 
 chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
     if (message.action === 'getAuth' && message.target === 'offscreen') {
         function handleIframeMessage({data}) {
             try {
                 const parsedData = JSON.parse(data);
+                console.log('Parsed data from iframe: ', parsedData.success);
                 window.removeEventListener('message', handleIframeMessage);
-                sendResponse(parsedData.user);
+                sendResponse(parsedData);
             } catch (e) {
                 console.error('Error parsing iframe message:', e);
             }

--- a/chrome-extension/src/background/background.js
+++ b/chrome-extension/src/background/background.js
@@ -1,3 +1,19 @@
+// 1. Import Firebase (Ensure you use the 'web-extension' path for MV3)
+import { initializeApp } from 'firebase/app';
+import { getAuth, GoogleAuthProvider, signInWithCredential } from 'firebase/auth/web-extension';
+import { getFirestore, doc, setDoc, collection } from 'firebase/firestore';
+
+// the config will be publicly visible in the extension's source code
+// but that's generally fine for Firebase client-side apps
+// and security is applied at the firestore rules level, not the client code level
+const firebaseConfig = {
+  //put config here
+}
+
+const app = initializeApp(firebaseConfig);
+const auth = getAuth(app);
+const db = getFirestore(app);
+
 const OFFSCREEN_DOCUMENT_PATH = 'offscreen.html';
 const FIREBASE_HOSTING_URL = 'https://your-project-id.web.app'; // Replace with your Firebase hosting URL
 
@@ -38,11 +54,36 @@ async function getAuthFromOffscreen() {
 }
 
 chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
+    if (message.target === 'offscreen') return false;
     if (message.action === 'signIn') {
         getAuthFromOffscreen()
             .then(user => {
-                chrome.storage.local.set({user: user}, () => {
-                    sendResponse({user: user});
+                if (user.success == false) {
+                    console.log('Received unsuccessful auth response from offscreen document');
+                    return sendResponse({error: user.error});
+                }
+                console.log('Received user from offscreen:', user.email+ " uid "+user.uid);
+                //token is not stored in the extension, only the minimal user info is stored for convenience,
+                // but the token is not stored since it can be easily obtained again from the offscreen document if needed, 
+                // storing it would require additional security considerations
+                const user_stored = {
+                    'email': user.email,
+                    'uid': user.uid,
+                    'name': user.displayName
+                };
+                try {
+                    signInWithFirebase(user.idToken); 
+                    writeTestData('chrom-ext-login', user.uid, {email: user.email, name: user.displayName, timestamp: new Date().toISOString()}, (response) => {
+                        // Handle response if needed
+                        console.log('Response from writeTestData:', response);
+                    });
+                } catch (error) {
+                    console.log('Error during local Firebase sign-in:', error);
+                    sendResponse({error: error.message});
+                }
+                chrome.storage.local.set({'user': user_stored}, () => {
+                        console.log('User stored in local storage:', user_stored);
+                        sendResponse({user: user_stored});
                 });
             })
             .catch(error => {
@@ -57,3 +98,38 @@ chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
         return true;
     }
 });
+
+
+async function signInWithFirebase(googleIdToken) {
+    // 2. THE KEY: Sign in the SDK using the ID Token, this allow us to directly read/write data to firestore
+    
+    const credential = GoogleAuthProvider.credential(googleIdToken);
+    const userCredential = await signInWithCredential(auth, credential);
+    //loggin uid to match it with other uid logs to ensure that the same user is authenticated in both places
+    console.log('Local Firebase sdk initialization successful:', userCredential.user.email +" uid "+userCredential.user.uid);
+    return userCredential;
+}
+
+function writeTestData(collection_name, uid, data, sendResponse) {
+   // setDoc will create or overwrite the document
+    data['uid'] = uid;
+    data['id'] = uid; 
+    setDoc(doc(db, 'chrom-last-login', uid), data)
+        .then(() => sendResponse({ success: true }))
+        .catch((error) => sendResponse({ success: false, error: error.message }));
+
+    const myCollection = collection(db, collection_name);
+
+    //to add a document with a auto generated Id
+    // 1. Create a reference with a generated ID (does NOT hit the network yet)
+    const newDocRef = doc(myCollection); 
+    const autoId = newDocRef.id;
+
+    // 2. Add the ID to your data object if you want
+    data['id'] = autoId ;
+    // 3. Save the document
+    setDoc(newDocRef, data)
+      .then(() => sendResponse({ success: true, id: autoId }))
+      .catch((error) => sendResponse({ success: false, error: error.message }));
+}
+

--- a/chrome-extension/webpack.config.js
+++ b/chrome-extension/webpack.config.js
@@ -13,11 +13,31 @@ module.exports = {
     path: path.resolve(__dirname, 'dist'),
     clean: true,
   },
+ module: {
+    rules: [
+      {
+        test: /\.js$/,
+        // This tells Webpack to automatically handle ESM vs CommonJS
+        // based on the presence of 'import' or 'require'
+        type: 'javascript/auto', 
+        resolve: {
+          // This ensures that 'import' works even if the file 
+          // doesn't have a .js extension in the code
+          fullySpecified: false, 
+        },
+      },
+    ],
+  },
+  resolve: {
+    // FIX: Ensures Webpack picks the ESM version of Firebase
+    mainFields: ['module', 'main'],
+    extensions: ['.js', '.mjs']
+  },
   plugins: [
     new HtmlWebpackPlugin({
       template: path.join(__dirname, "src", "popup", "popup.html"),
       filename: "popup.html",
-      chunks: ["firebase_config"]
+      chunks: ["popup"]
     }),
     new CopyWebpackPlugin({
       patterns: [

--- a/chrome-extension/webpack.config.js
+++ b/chrome-extension/webpack.config.js
@@ -25,4 +25,5 @@ module.exports = {
       ],
     }),
   ],
+  devtool: 'cheap-module-source-map',
 };

--- a/firebase-project/public/signInWithPopup.js
+++ b/firebase-project/public/signInWithPopup.js
@@ -1,6 +1,9 @@
-import { initializeApp } from 'firebase/app';
-import { getAuth, signInWithPopup, GoogleAuthProvider } from 'firebase/auth';
+import { initializeApp } from 'https://www.gstatic.com/firebasejs/12.10.0/firebase-app.js';
+import { getAuth, signInWithPopup, GoogleAuthProvider } from 'https://www.gstatic.com/firebasejs/12.10.0/firebase-auth.js';
 
+// the config will be publicly visible in the extension's source code
+// but that's generally fine for Firebase client-side apps
+// and security is applied at the firestore rules level, not the client code level
 const firebaseConfig = {
   // Your web app's Firebase configuration
   // Replace with the config you copied from Firebase Console
@@ -8,6 +11,7 @@ const firebaseConfig = {
 
 const app = initializeApp(firebaseConfig);
 const auth = getAuth();
+let isAuthInProgress = false; // The Lock
 
 // This gives you a reference to the parent frame, i.e. the offscreen document.
 const PARENT_FRAME = document.location.ancestorOrigins[0];
@@ -15,13 +19,49 @@ const PARENT_FRAME = document.location.ancestorOrigins[0];
 const PROVIDER = new GoogleAuthProvider();
 
 function sendResponse(result) {
-  window.parent.postMessage(JSON.stringify(result), PARENT_FRAME);
+  const credential = GoogleAuthProvider.credentialFromResult(result);
+  const minimalData = {
+        success: true,
+        idToken: credential.idToken,
+        uid: result.user.uid,
+        email: result.user.email,
+        displayName: result.user.displayName
+      };
+  console.log(`Auth Flow: Success! Authenticated as ${minimalData.email}`);
+  window.parent.postMessage(JSON.stringify(minimalData), PARENT_FRAME);
 }
 
-window.addEventListener('message', function({data}) {
+function sendError(error) {
+  console.log("Auth Flow: Error during sign-in:", error);
+  const errorData = {
+    success: false,
+    error: error,
+    code: -1
+  };
+  window.parent.postMessage(JSON.stringify(errorData), PARENT_FRAME);
+}
+window.addEventListener('message', async function({data}) {
   if (data.initAuth) {
-    signInWithPopup(auth, PROVIDER)
-      .then(sendResponse)
-      .catch(sendResponse);
-  }
+    if (isAuthInProgress) {
+      console.log("Auth already in progress, ignoring duplicate request.");
+      return;
+    }
+    isAuthInProgress = true;
+    console.log("Auth Flow: Received results from Extension. Opening Popup...");
+    
+    try {
+      const result = await signInWithPopup(auth, PROVIDER);
+      sendResponse(result);
+    } catch (error) {
+      // Only log if it's NOT a cancellation we caused
+      if (error.code !== 'auth/cancelled-popup-request') {
+        sendError(error);
+      }
+    } finally {
+      isAuthInProgress = false; // Unlock it
+    }
+
+  } else {
+    console.log("Auth Flow: Received message from Extension, but it doesn't have the expected initAuth property. Ignoring.");
+  } 
 });


### PR DESCRIPTION

### Description:
Refactored the Chrome extension to support direct Firestore/Database read/write operations while maintaining Google Login via an offscreen document. This approach adds the core logic into the extension's background script, removing the need to handle data operations inside separate hosted web app.

### Key Changes:

**Architectural Note**: Firebase SDK is now initialized locally also within background.js using an ID token passed from firebase Project, while login still remains with existing firebase project.

**Security & Compliance**: Bundled the Firebase SDK locally to comply with Chrome’s "No Remote Code Execution" policy.

**CSP Updates**: Updated Content Security Policies to allow the offscreen frame to load the "thin" Firebase auth app without being blocked.

**Optimization**: Modified the Firebase project to pass only essential initialization data to the parent frame, successfully eliminating "ghost events."

_Note_: See README.md for specific implementation details and edge cases.